### PR TITLE
Don’t use goto-char

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore"
+    include: "scope"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: purcell/setup-emacs@master
       with:
-        version: 29.1
+        version: 29.3
     - uses: actions/checkout@v4
     - name: Run tests
       run: make package-lint
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.1
-          - 25.3
           - 26.1
           - 26.3
           - 27.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,16 @@ on:
     - '**.md'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: purcell/setup-emacs@master
+      with:
+        version: 29.1
+    - uses: actions/checkout@v2
+    - name: Run tests
+      run: make package-lint
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -18,6 +28,7 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - 29.1
           - release-snapshot
           - snapshot
     steps:
@@ -32,4 +43,4 @@ jobs:
     - name: Install deps for tests
       run: nix-env -i direnv -f '<nixpkgs>'
     - name: Run tests
-      run: make
+      run: make compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - release-snapshot
           - snapshot
     steps:
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v23
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - 28.2
           - snapshot
     steps:
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v22
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Install deps for tests
       run: nix-env -i direnv -f '<nixpkgs>'
     - name: Run tests
-      run: make compile
+      run: make compile test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - release-snapshot
           - snapshot
     steps:
     - uses: cachix/install-nix-action@v22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,22 @@ jobs:
       matrix:
         emacs_version:
           - 25.1
-          - 25.2
           - 25.3
           - 26.1
-          - 26.2
           - 26.3
           - 27.2
           - 28.1
           - 28.2
           - snapshot
     steps:
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install deps for tests
       run: nix-env -i direnv -f '<nixpkgs>'
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install deps for tests
       run: nix-env -i direnv -f '<nixpkgs>'
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,6 @@ jobs:
 
     - uses: actions/checkout@v4
     - name: Install deps for tests
-      run: nix-env -i direnv -f '<nixpkgs>'
+      run: nix profile install 'nixpkgs#direnv'
     - name: Run tests
       run: make compile test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    paths-ignore:
-    - '**.md'
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - 28.1
           - 28.2
           - 29.1
+          - 29.3
           - release-snapshot
           - snapshot
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - release-snapshot
           - snapshot
     steps:
-    - uses: cachix/install-nix-action@v23
+    - uses: cachix/install-nix-action@v26
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: purcell/setup-emacs@master
       with:
         version: 29.1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run tests
       run: make package-lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - release-snapshot
           - snapshot
     steps:
-    - uses: cachix/install-nix-action@v26
+    - uses: cachix/install-nix-action@V27
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ INIT_PACKAGES := "(progn \
 all: compile test package-lint clean-elc
 
 test:
-	${EMACS} -Q --eval $(subst PACKAGES,${DEPS,}${INIT_PACKAGES}) -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
+	${EMACS} -Q --eval $(subst PACKAGES,${DEPS},${INIT_PACKAGES}) -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
 
 package-lint:
 	${EMACS} -Q --eval $(subst PACKAGES,package-lint,${INIT_PACKAGES}) -batch -f package-lint-batch-and-exit envrc.el
 
 compile: clean-elc
-	${EMACS} -Q --eval $(subst PACKAGES,${DEPS,}${INIT_PACKAGES}) -L . -batch -f batch-byte-compile *.el
+	${EMACS} -Q --eval $(subst PACKAGES,${DEPS},${INIT_PACKAGES}) -L . -batch -f batch-byte-compile *.el
 
 clean-elc:
 	rm -f f.elc

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 EMACS ?= emacs
 
 # A space-separated list of required package names
-NEEDED_PACKAGES = package-lint seq inheritenv
+DEPS = seq inheritenv
 
-INIT_PACKAGES="(progn \
+INIT_PACKAGES := "(progn \
   (require 'package) \
   (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
   (package-initialize) \
-  (dolist (pkg '(${NEEDED_PACKAGES})) \
+  (dolist (pkg '(PACKAGES)) \
     (unless (package-installed-p pkg) \
       (unless (assoc pkg package-archive-contents) \
         (package-refresh-contents)) \
@@ -17,13 +17,13 @@ INIT_PACKAGES="(progn \
 all: compile test package-lint clean-elc
 
 test:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
+	${EMACS} -Q --eval $(subst PACKAGES,${DEPS,}${INIT_PACKAGES}) -batch -l envrc.el -l envrc-tests.el -f ert-run-tests-batch-and-exit
 
 package-lint:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit envrc.el
+	${EMACS} -Q --eval $(subst PACKAGES,package-lint,${INIT_PACKAGES}) -batch -f package-lint-batch-and-exit envrc.el
 
 compile: clean-elc
-	${EMACS} -Q --eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile *.el
+	${EMACS} -Q --eval $(subst PACKAGES,${DEPS,}${INIT_PACKAGES}) -L . -batch -f batch-byte-compile *.el
 
 clean-elc:
 	rm -f f.elc

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ executables. Counter-intuitively, this means that `envrc-global-mode`
 should be enabled *after* other global minor modes, since each
 _prepends_ itself to various hooks.
 
-You should only enable the mode if `direnv` is installed and available
-in the default Emacs `exec-path`. (There is a local minor mode
-`envrc-mode`, but you should not try to enable this granularly,
+The global mode will only have an effect if `direnv` is installed and
+available in the default Emacs `exec-path`. (There is a local minor
+mode `envrc-mode`, but you should not try to enable this granularly,
 e.g. for certain modes or projects, because compilation and other
 buffers might not get set up with the right environment.)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Melpa Status](http://melpa.org/packages/envrc-badge.svg)](https://melpa.org/#/envrc)
 [![Melpa Stable Status](http://stable.melpa.org/packages/envrc-badge.svg)](http://stable.melpa.org/#/envrc)
-[![Build Status](https://github.com/purcell/envrc/workflows/CI/badge.svg)](https://github.com/purcell/envrc/actions)
+[![Build Status](https://github.com/purcell/envrc/actions/workflows/test.yml/badge.svg)](https://github.com/purcell/envrc/actions/workflows/test.yml)
 <a href="https://www.patreon.com/sanityinc"><img alt="Support me" src="https://img.shields.io/badge/Support%20Me-%F0%9F%92%97-ff69b4.svg"></a>
 
 # envrc.el - buffer-local direnv integration for Emacs

--- a/README.md
+++ b/README.md
@@ -37,14 +37,23 @@ the latest release or clone the repository, and install
 
 ## Usage
 
-Add the following to your `init.el` (after calling `package-initialize`):
+Add a snippet like the following at the **bottom of your `init.el`**:
 
 ```el
 (envrc-global-mode)
 ```
+or
+```el
+(add-hook 'after-init-hook 'envrc-global-mode)
+```
+or, if you're a `use-package` fan:
+```el
+(use-package envrc
+  :hook (after-init . envrc-global-mode))
+```
 
-It's probably wise to do this *late in your startup sequence*: you
-normally want `envrc-mode` to be initialized in each buffer *before*
+Why must you enable the global mode *late in your startup sequence* like this? 
+You normally want `envrc-mode` to be initialized in each buffer *before*
 other minor modes like `flycheck-mode` which might look for
 executables. Counter-intuitively, this means that `envrc-global-mode`
 should be enabled *after* other global minor modes, since each

--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ the environment variables specified in those files. This allows
 different versions of linters and other tools to be used in each
 project if desired.
 
-This library is like [the `direnv.el`
-package](https://github.com/wbolster/emacs-direnv), but sets all
-environment variables buffer-locally, while `direnv.el` changes
-the global set of environment variables after each command.
+## How does this differ from `direnv.el`?
+
+[`direnv.el`](https://github.com/wbolster/emacs-direnv) repeatedly
+changes the global Emacs environment, based on tracking what buffer
+you're working on.
+
+Instead, `envrc.el` simply sets and stores the right environment in
+each buffer, as a buffer-local variable.
+
+From a user perspective, both are well tested and typically work fine,
+but the `envrc.el` approach feels cleaner to me.
 
 ## Installation
 

--- a/envrc.el
+++ b/envrc.el
@@ -137,9 +137,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
       (progn
         (envrc--update)
         (when (and (derived-mode-p 'eshell-mode) envrc-update-on-eshell-directory-change)
-          (add-hook 'eshell-directory-change-hook #'envrc--update nil t))
-        (when (derived-mode-p 'compilation-mode)
-          (add-hook 'compilation-mode-hook #'envrc--update nil t)))
+          (add-hook 'eshell-directory-change-hook #'envrc--update nil t)))
     (envrc--clear (current-buffer))
     (remove-hook 'eshell-directory-change-hook #'envrc--update t)))
 
@@ -212,7 +210,8 @@ since its output can vary according to its initial environment."
   "Update the current buffer's environment if it is managed by direnv.
 All envrc.el-managed buffers with this env will have their
 environments updated."
-  (let ((env-dir (envrc--find-env-dir)))
+  (let ((env-dir (envrc--find-env-dir))
+        (buf (current-buffer)))
     (if env-dir
         (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment))))
           (pcase (gethash cache-key envrc--cache 'missing)
@@ -220,9 +219,9 @@ environments updated."
              (envrc--export env-dir
                             (lambda (result)
                               (puthash cache-key result envrc--cache)
-                              (envrc--apply (current-buffer) result))))
-            (cached (envrc--apply (current-buffer) cached))))
-      (envrc--apply (current-buffer) 'none))))
+                              (envrc--apply buf result))))
+            (cached (envrc--apply buf cached))))
+      (envrc--apply buf 'none))))
 
 
 (defmacro envrc--at-end-of-special-buffer (name &rest body)

--- a/envrc.el
+++ b/envrc.el
@@ -356,7 +356,9 @@ DIRECTORY is the directory in which the environment changes."
        (let ((process (gethash cache-key envrc--running-process)))
          (if (and process (memq (process-status proc) '(open run stop)))
              (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)
-           (remhash cache-key envrc--running-process)))))))
+           (progn
+             (remhash cache-key envrc--running-process)
+             (envrc--export-new-process env-dir callback))))))))
 
 ;; Forward declaration for the byte compiler
 (defvar eshell-path-env)

--- a/envrc.el
+++ b/envrc.el
@@ -276,7 +276,8 @@ Return value is either \\='error, \\='none, or an alist of environment
 variable names and values."
   (unless (envrc--env-dir-p env-dir)
     (error "%s is not a directory with a .envrc" env-dir))
-  (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment))))
+  (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment)))
+        result)
     (pcase (gethash cache-key envrc--running-processes-callbacks 'missing)
       (`missing
        (message "Running direnv in %s..." env-dir)

--- a/envrc.el
+++ b/envrc.el
@@ -354,7 +354,7 @@ DIRECTORY is the directory in which the environment changes."
       (callbacks
        ;; Make sure process is still running.
        (let ((process (gethash cache-key envrc--running-processes)))
-         (if (and process (memq (process-status proc) '(open run stop)))
+         (if (and process (memq (process-status process) '(open run stop)))
              (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)
            (progn
              (remhash cache-key envrc--running-processes)

--- a/envrc.el
+++ b/envrc.el
@@ -91,7 +91,9 @@ Messages are written into the *envrc-debug* buffer."
 
 (define-obsolete-variable-alias 'envrc--lighter 'envrc-lighter "2021-05-17")
 
-(defcustom envrc-lighter '(:eval (envrc--lighter))
+(defcustom envrc-lighter '(:propertize (:eval (envrc--lighter))
+                                       mouse-face mode-line-highlight
+                                       local-map (keymap (mode-line keymap (down-mouse-1 . envrc-show-log))))
   "The mode line lighter for `envrc-mode'.
 You can set this to nil to disable the lighter."
   :type 'sexp)

--- a/envrc.el
+++ b/envrc.el
@@ -220,7 +220,7 @@ All envrc.el-managed buffers with this env will have their
 environments updated."
   (let ((env-dir (envrc--find-env-dir))
         (buf (current-buffer)))
-    (setq-local envrc--status (if (listp result) 'updating result))
+    (setq-local envrc--status 'updating)
     (if env-dir
         (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment))))
           (pcase (gethash cache-key envrc--cache 'missing)

--- a/envrc.el
+++ b/envrc.el
@@ -303,7 +303,7 @@ variable names and values."
                   (prog1
                       (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))
                     (when envrc-show-summary-in-minibuffer
-                          (envrc--show-summary result env-dir)))))
+                      (envrc--show-summary result env-dir)))))
             (message "Direnv failed in %s" env-dir)
             (setq result 'error))
           (envrc--at-end-of-special-buffer "*envrc*"
@@ -454,9 +454,9 @@ the exit code, stdout and stderr of the process."
                  (unless (string= event "run\n")
                    (let* ((stdout (with-current-buffer (process-buffer process) (buffer-string)))
                           (stderr (with-current-buffer stderr-buffer (buffer-string))))
-                    (funcall callback (process-exit-status process) stdout stderr)
-                    (kill-buffer (process-buffer process))
-                    (kill-buffer stderr-buffer)))))))
+                     (funcall callback (process-exit-status process) stdout stderr)
+                     (kill-buffer (process-buffer process))
+                     (kill-buffer stderr-buffer)))))))
 
 (defun envrc-reload ()
   "Reload the current env."
@@ -468,17 +468,17 @@ the exit code, stdout and stderr of the process."
   "Run \"direnv allow\" in the current env."
   (interactive)
   (envrc--with-required-current-env env-dir
-     (let* ((default-directory env-dir))
-        (envrc--make-process-with-global-env
-         `("direnv" "allow")
-          (lambda (exit-code stdout stderr)
-           (if (zerop exit-code)
-               (with-current-buffer (get-buffer-create "*envrc-allow*")
-                 (erase-buffer)
-                 (insert stdout)
-                 (insert stderr)
-                 (display-buffer (current-buffer)))
-               (user-error "Error running direnv allow")))))))
+    (let* ((default-directory env-dir))
+      (envrc--make-process-with-global-env
+       `("direnv" "allow")
+       (lambda (exit-code stdout stderr)
+         (if (zerop exit-code)
+             (with-current-buffer (get-buffer-create "*envrc-allow*")
+               (erase-buffer)
+               (insert stdout)
+               (insert stderr)
+               (display-buffer (current-buffer)))
+           (user-error "Error running direnv allow")))))))
 
 (defun envrc-deny ()
   "Run \"direnv deny\" in the current env."
@@ -487,14 +487,14 @@ the exit code, stdout and stderr of the process."
     (let* ((default-directory env-dir))
       (envrc--make-process-with-global-env
        `("direnv" "deny")
-        (lambda (exit-code stdout stderr)
+       (lambda (exit-code stdout stderr)
          (if (zerop exit-code)
              (with-current-buffer (get-buffer-create "*envrc-deny*")
                (erase-buffer)
                (insert stdout)
                (insert stderr)
                (display-buffer (current-buffer)))
-             (user-error "Error running direnv deny")))))))
+           (user-error "Error running direnv deny")))))))
 
 (defun envrc-reload-all ()
   "Reload direnvs for all buffers.

--- a/envrc.el
+++ b/envrc.el
@@ -173,6 +173,9 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
   "Known envrc directories and their direnv results.
 The values are as produced by `envrc--export'.")
 
+(defvar envrc--running-processes (make-hash-table :test 'equal :size 10)
+  "Processes running by envrc.")
+
 (defvar envrc--running-processes-callbacks (make-hash-table :test 'equal :size 10)
   "Callbacks for each process running by envrc.")
 
@@ -298,52 +301,62 @@ DIRECTORY is the directory in which the environment changes."
            (propertize (concat "(" (abbreviate-file-name (directory-file-name directory)) ")")
                        'face 'font-lock-comment-face)))
 
+(defun envrc--export-new-process (env-dir callback)
+  "Export the env vars for ENV-DIR using direnv."
+  (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment)))
+        result
+        process)
+    (message "Running direnv in %s..." env-dir)
+    (puthash cache-key (cons callback ()) envrc--running-processes-callbacks)
+    (puthash cache-key (envrc--make-process-with-global-env
+                        `("direnv" "export" "json")
+                        (lambda (exit-code stdout stderr)
+                          (envrc--debug "Direnv exited with %s and stderr=%S, stdout=%S" exit-code stderr stdout)
+                          (if (zerop exit-code)
+                              (progn
+                                (message "Direnv succeeded in %s" env-dir)
+                                (if (length= stdout 0)
+                                    (setq result 'none)
+                                  (prog1
+                                      (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))
+                                    (when envrc-show-summary-in-minibuffer
+                                      (envrc--show-summary result env-dir)))))
+                            (message "Direnv failed in %s" env-dir)
+                            (setq result 'error))
+                          (envrc--at-end-of-special-buffer (envrc--log-buffer-name)
+                            (insert "==== " (format-time-string "%Y-%m-%d %H:%M:%S") " ==== " env-dir " ====\n\n")
+                            (let ((initial-pos (point)))
+                              (insert (let (ansi-color-context) (ansi-color-apply stderr)))
+                              (goto-char (point-max))
+                              (add-face-text-property initial-pos (point) (if (zerop exit-code) 'success 'error)))
+                            (insert "\n\n")
+                            (unless (eq 0 exit-code) ;; zerop is not an option, as exit-code may sometimes be a symbol
+                              (message "%s" stderr)))
+
+                          ;; check again for callbacks in case they got added while this was running
+                          (pcase (gethash cache-key envrc--running-processes-callbacks 'missing)
+                            (`missing (error "envrc--export: no callbacks found"))
+                            (callbacks
+                             (remhash cache-key envrc--running-processes-callbacks)
+                             (dolist (x callbacks) (funcall x result))))
+                          (remhash cache-key envrc--running-processes)))
+             envrc--running-processes)))
+
 (defun envrc--export (env-dir callback)
-  "Export the env vars for ENV-DIR using direnv.
-Return value is either \\='error, \\='none, or an alist of environment
-variable names and values."
+  "Export the env vars for ENV-DIR using direnv."
   (unless (envrc--env-dir-p env-dir)
     (error "%s is not a directory with a .envrc" env-dir))
   (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment)))
         result)
     (pcase (gethash cache-key envrc--running-processes-callbacks 'missing)
       (`missing
-       (message "Running direnv in %s..." env-dir)
-       (puthash cache-key (cons callback ()) envrc--running-processes-callbacks)
-       (envrc--make-process-with-global-env
-        `("direnv" "export" "json")
-        (lambda (exit-code stdout stderr)
-          (envrc--debug "Direnv exited with %s and stderr=%S, stdout=%S" exit-code stderr stdout)
-          (if (zerop exit-code)
-              (progn
-                (message "Direnv succeeded in %s" env-dir)
-                (if (eq (length stdout) 0)
-                    (setq result 'none)
-                  (prog1
-                      (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))
-                    (when envrc-show-summary-in-minibuffer
-                      (envrc--show-summary result env-dir)))))
-            (message "Direnv failed in %s" env-dir)
-            (setq result 'error))
-          (envrc--at-end-of-special-buffer "*envrc*"
-            (insert "==== " (format-time-string "%Y-%m-%d %H:%M:%S") " ==== " env-dir " ====\n\n")
-            (let ((initial-pos (point)))
-              (insert (let (ansi-color-context) (ansi-color-apply stderr)))
-              (goto-char (point-max))
-              (add-face-text-property initial-pos (point) (if (zerop exit-code) 'success 'error)))
-            (insert "\n\n")
-            (unless (eq 0 exit-code) ;; zerop is not an option, as exit-code may sometimes be a symbol
-              (message "%s" stderr)))
-
-          ;; check again for callbacks in case they got added while this was running
-          (pcase (gethash cache-key envrc--running-processes-callbacks 'missing)
-            (`missing (error "envrc--export: no callbacks found"))
-            (callbacks
-             (remhash cache-key envrc--running-processes-callbacks)
-             (dolist (x callbacks) (funcall x result)))))))
-      (callbacks (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)))))
-
-
+       (envrc--export-new-process env-dir callback))
+      (callbacks
+       ;; Make sure process is still running.
+       (let ((process (gethash cache-key envrc--running-process)))
+         (if (and process (memq (process-status proc) '(open run stop)))
+             (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)
+           (remhash cache-key envrc--running-process)))))))
 
 ;; Forward declaration for the byte compiler
 (defvar eshell-path-env)

--- a/envrc.el
+++ b/envrc.el
@@ -307,7 +307,7 @@ DIRECTORY is the directory in which the environment changes."
         result
         process)
     (message "Running direnv in %s..." env-dir)
-    (puthash cache-key (cons callback ()) envrc--running-processes-callbacks)
+    (puthash cache-key (cons callback (gethash cache-key envrc--running-processes-callbacks)) envrc--running-processes-callbacks)
     (puthash cache-key (envrc--make-process-with-global-env
                         `("direnv" "export" "json")
                         (lambda (exit-code stdout stderr)

--- a/envrc.el
+++ b/envrc.el
@@ -353,11 +353,11 @@ DIRECTORY is the directory in which the environment changes."
        (envrc--export-new-process env-dir callback))
       (callbacks
        ;; Make sure process is still running.
-       (let ((process (gethash cache-key envrc--running-process)))
+       (let ((process (gethash cache-key envrc--running-processes)))
          (if (and process (memq (process-status proc) '(open run stop)))
              (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)
            (progn
-             (remhash cache-key envrc--running-process)
+             (remhash cache-key envrc--running-processes)
              (envrc--export-new-process env-dir callback))))))))
 
 ;; Forward declaration for the byte compiler

--- a/envrc.el
+++ b/envrc.el
@@ -451,12 +451,7 @@ the exit code, stdout and stderr of the process."
   "Reload the current env."
   (interactive)
   (envrc--with-required-current-env env-dir
-    (let* ((default-directory env-dir)
-           (exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (get-buffer-create "*envrc-reload*") nil "reload")))
-      (if (zerop exit-code)
-          (envrc--update-env env-dir)
-        (display-buffer "*envrc-reload*")
-        (user-error "Error running direnv reload")))))
+    (envrc--update-env env-dir)))
 
 (defun envrc-allow ()
   "Run \"direnv allow\" in the current env."

--- a/envrc.el
+++ b/envrc.el
@@ -238,9 +238,8 @@ variable names and values."
       (if (zerop exit-code)
           (progn
             (message "Direnv succeeded in %s" env-dir)
-            (if (zerop (buffer-size))
+            (if (length= stdout 0)
                 (setq result 'none)
-              (goto-char (point-min))
               (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))))
         (message "Direnv failed in %s" env-dir)
         (setq result 'error))

--- a/envrc.el
+++ b/envrc.el
@@ -97,7 +97,7 @@ You can set this to nil to disable the lighter."
   :type 'sexp)
 (put 'envrc-lighter 'risky-local-variable t)
 
-(defcustom envrc-none-lighter '(" envrc[" (:propertize "none" face envrc-mode-line-none-face) "]")
+(defcustom envrc-none-lighter nil
   "Lighter spec used by the default `envrc-lighter' when envrc is inactive."
   :type 'sexp)
 

--- a/envrc.el
+++ b/envrc.el
@@ -93,7 +93,9 @@ Messages are written into the *envrc-debug* buffer."
 
 (defcustom envrc-lighter '(:propertize (:eval (envrc--lighter))
                                        mouse-face mode-line-highlight
-                                       local-map (keymap (mode-line keymap (down-mouse-1 . envrc-show-log))))
+                                       local-map (keymap
+                                                  (mode-line keymap
+                                                             (down-mouse-1 . envrc-show-log))))
   "The mode line lighter for `envrc-mode'.
 You can set this to nil to disable the lighter."
   :type 'sexp)
@@ -234,14 +236,29 @@ environments updated."
             (cached (envrc--apply buf cached))))
       (envrc--apply buf 'none))))
 
+(defvar envrc-log-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "g" #'envrc-reload)
+    map))
+
+;;;###autoload
+(define-derived-mode envrc-log-mode special-mode "Envrc Log"
+  "Major mode for Envrc log buffer.")
+
+(defun envrc--log-buffer-name ()
+  "Buffer name to use for envrc log buffers."
+  (concat "*"
+          (file-name-nondirectory
+           (directory-file-name default-directory))
+          "-envrc*"))
 
 (defmacro envrc--at-end-of-special-buffer (name &rest body)
   "At the end of `special-mode' buffer NAME, execute BODY.
 To avoid confusion, `envrc-mode' is explicitly disabled in the buffer."
   (declare (indent 1))
   `(with-current-buffer (get-buffer-create ,name)
-     (unless (derived-mode-p 'special-mode)
-       (special-mode))
+     (unless (derived-mode-p 'envrc-log-mode)
+       (envrc-log-mode))
      (when envrc-mode (envrc-mode -1))
      (goto-char (point-max))
      (let ((inhibit-read-only t))

--- a/envrc.el
+++ b/envrc.el
@@ -287,7 +287,7 @@ variable names and values."
           (if (zerop exit-code)
               (progn
                 (message "Direnv succeeded in %s" env-dir)
-                (if (length= stdout 0)
+                (if (eq (length stdout) 0)
                     (setq result 'none)
                   (prog1
                       (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))

--- a/envrc.el
+++ b/envrc.el
@@ -335,7 +335,7 @@ DIRECTORY is the directory in which the environment changes."
 
                           ;; check again for callbacks in case they got added while this was running
                           (pcase (gethash cache-key envrc--running-processes-callbacks 'missing)
-                            (`missing (error "envrc--export: no callbacks found"))
+                            (`missing nil)
                             (callbacks
                              (remhash cache-key envrc--running-processes-callbacks)
                              (dolist (x callbacks) (funcall x result))))

--- a/envrc.el
+++ b/envrc.el
@@ -105,6 +105,10 @@ You can set this to nil to disable the lighter."
   "Lighter spec used by the default `envrc-lighter' when envrc is on."
   :type 'sexp)
 
+(defcustom envrc-updating-lighter '(" envrc[" (:propertize "updating" face envrc-mode-line-updating-face) "]")
+  "Lighter spec used by the default `envrc-lighter' when envrc is updating."
+  :type 'sexp)
+
 (defcustom envrc-error-lighter '(" envrc[" (:propertize "error" face envrc-mode-line-error-face) "]")
   "Lighter spec used by the default `envrc-lighter' when envrc has errored."
   :type 'sexp)
@@ -153,6 +157,9 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
 (defface envrc-mode-line-error-face '((t :inherit error))
   "Face used in mode line to indicate that direnv failed.")
 
+(defface envrc-mode-line-updating-face '((t :inherit warning))
+  "Face used in mode line to indicate that direnv is not active.")
+
 (defface envrc-mode-line-none-face '((t :inherit warning))
   "Face used in mode line to indicate that direnv is not active.")
 
@@ -177,6 +184,7 @@ One of \\='(none on error).")
   "Return a colourised version of `envrc--status' for use in the mode line."
   (pcase envrc--status
     (`on envrc-on-lighter)
+    (`updating envrc-updating-lighter)
     (`error envrc-error-lighter)
     (`none envrc-none-lighter)))
 
@@ -212,6 +220,7 @@ All envrc.el-managed buffers with this env will have their
 environments updated."
   (let ((env-dir (envrc--find-env-dir))
         (buf (current-buffer)))
+    (setq-local envrc--status (if (listp result) 'updating result))
     (if env-dir
         (let ((cache-key (envrc--cache-key env-dir (default-value 'process-environment))))
           (pcase (gethash cache-key envrc--cache 'missing)

--- a/envrc.el
+++ b/envrc.el
@@ -137,7 +137,9 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
       (progn
         (envrc--update)
         (when (and (derived-mode-p 'eshell-mode) envrc-update-on-eshell-directory-change)
-          (add-hook 'eshell-directory-change-hook #'envrc--update nil t)))
+          (add-hook 'eshell-directory-change-hook #'envrc--update nil t))
+        (when (derived-mode-p 'compilation-mode)
+          (add-hook 'compilation-mode-hook #'envrc--update nil t)))
     (envrc--clear (current-buffer))
     (remove-hook 'eshell-directory-change-hook #'envrc--update t)))
 

--- a/envrc.el
+++ b/envrc.el
@@ -144,7 +144,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") 'envrc-command-map)"
 ;;; Global state
 
 (defvar envrc--cache (make-hash-table :test 'equal :size 10)
-  "Known envrc directorie and their direnv results.
+  "Known envrc directories and their direnv results.
 The values are as produced by `envrc--export'.")
 
 ;;; Local state

--- a/envrc.el
+++ b/envrc.el
@@ -442,6 +442,8 @@ in a temp buffer.  ARGS is as for ORIG."
     "use" "use_guix" "use_flake" "use_nix" "user_rel_path" "watch_dir" "watch_file")
   "Useful direnv keywords to be highlighted.")
 
+(declare-function sh-set-shell "sh-script")
+
 ;;;###autoload
 (define-derived-mode envrc-file-mode
   sh-mode "envrc"

--- a/envrc.el
+++ b/envrc.el
@@ -104,6 +104,7 @@ You can set this to nil to disable the lighter."
     (define-key map (kbd "a") 'envrc-allow)
     (define-key map (kbd "d") 'envrc-deny)
     (define-key map (kbd "r") 'envrc-reload)
+    (define-key map (kbd "l") 'envrc-show-log)
     map)
   "Keymap for commands in `envrc-mode'.
 See `envrc-mode-map' for how to assign a prefix binding to these."
@@ -395,6 +396,12 @@ This can be useful if a .envrc has been deleted."
     (with-current-buffer buf
       (envrc--update))))
 
+(defun envrc-show-log ()
+  "Open envrc log buffer."
+  (interactive)
+  (if-let ((buffer (get-buffer "*envrc*")))
+      (pop-to-buffer buffer)
+    (message "Envrc log buffer does not exist")))
 
 
 ;;; Propagate local environment to commands that use temp buffers

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
-;; Package-Version: 0
+;; Package-Version: 0.6
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -543,7 +543,7 @@ This can be useful if a .envrc has been deleted."
 (defun envrc-show-log ()
   "Open envrc log buffer."
   (interactive)
-  (if-let ((buffer (get-buffer "*envrc*")))
+  (if-let* ((buffer (get-buffer "*envrc*")))
       (pop-to-buffer buffer)
     (message "Envrc log buffer does not exist")))
 

--- a/envrc.el
+++ b/envrc.el
@@ -255,7 +255,7 @@ variable names and values."
                               (insert-file-contents stderr-file)
                               (buffer-string))
                             (buffer-string))
-              (if (eq 0 exit-code)
+              (if (zerop exit-code)
                   (progn
                     (message "Direnv succeeded in %s" env-dir)
                     (if (zerop (buffer-size))

--- a/envrc.el
+++ b/envrc.el
@@ -356,7 +356,12 @@ ARGS is as for `call-process'."
   "Reload the current env."
   (interactive)
   (envrc--with-required-current-env env-dir
-    (envrc--update-env env-dir)))
+    (let* ((default-directory env-dir)
+           (exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (get-buffer-create "*envrc-allow*") nil "reload")))
+      (if (zerop exit-code)
+          (envrc--update-env env-dir)
+        (display-buffer "*envrc-reload*")
+        (user-error "Error running direnv reload")))))
 
 (defun envrc-allow ()
   "Run \"direnv allow\" in the current env."

--- a/envrc.el
+++ b/envrc.el
@@ -299,6 +299,7 @@ also appear in PAIRS."
   (with-current-buffer buf
     (kill-local-variable 'exec-path)
     (kill-local-variable 'process-environment)
+    (kill-local-variable 'info-directory-list)
     (when (derived-mode-p 'eshell-mode)
       (if (fboundp 'eshell-set-path)
           (eshell-set-path (butlast exec-path))
@@ -320,7 +321,9 @@ also appear in PAIRS."
         (when (derived-mode-p 'eshell-mode)
           (if (fboundp 'eshell-set-path)
               (eshell-set-path path)
-            (setq-local eshell-path-env path)))))))
+            (setq-local eshell-path-env path))))
+      (when-let ((info-path (getenv "INFOPATH")))
+        (setq-local Info-directory-list (parse-colon-path info-path))))))
 
 (defun envrc--update-env (env-dir)
   "Refresh the state of the direnv in ENV-DIR and apply in all relevant buffers."

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
-;; Package-Version: 0.8
+;; Package-Version: 0.9
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -129,7 +129,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") 'envrc-command-map)"
   (if envrc-mode
       (progn
         (envrc--update)
-        (when (and (equal major-mode 'eshell-mode) envrc-update-on-eshell-directory-change)
+        (when (and (derived-mode-p 'eshell-mode) envrc-update-on-eshell-directory-change)
           (add-hook 'eshell-directory-change-hook #'envrc--update nil t)))
     (envrc--clear (current-buffer))
     (remove-hook 'eshell-directory-change-hook #'envrc--update t)))

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((emacs "26.1") (inheritenv "0.1"))
-;; Package-Version: 0.11
+;; Package-Version: 0.12
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -322,7 +322,7 @@ also appear in PAIRS."
           (if (fboundp 'eshell-set-path)
               (eshell-set-path path)
             (setq-local eshell-path-env path))))
-      ;; tell info.el to parse INFOPATH again in case direnv modified it
+      ;; Force info.el to parse INFOPATH again in case direnv modified it
       (when (getenv "INFOPATH") (setq-local Info-directory-list nil)))))
 
 (defun envrc--update-env (env-dir)

--- a/envrc.el
+++ b/envrc.el
@@ -117,14 +117,14 @@ You can set this to nil to disable the lighter."
     map)
   "Keymap for commands in `envrc-mode'.
 See `envrc-mode-map' for how to assign a prefix binding to these."
-  :type 'keymap)
+  :type '(restricted-sexp :match-alternatives (keymapp)))
 (fset 'envrc-command-map envrc-command-map)
 
 (defcustom envrc-mode-map (make-sparse-keymap)
   "Keymap for `envrc-mode'.
 To access `envrc-command-map' from this map, give it a prefix keybinding,
 e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
-  :type 'keymap)
+  :type '(restricted-sexp :match-alternatives (keymapp)))
 
 ;;;###autoload
 (define-minor-mode envrc-mode

--- a/envrc.el
+++ b/envrc.el
@@ -229,20 +229,24 @@ Return value is either 'error, 'none, or an alist of environment
 variable names and values."
   (unless (envrc--env-dir-p env-dir)
     (error "%s is not a directory with a .envrc" env-dir))
-  (message "Running direnv in %s..." env-dir)
+  (message "Running direnv in %s ... (C-g to abort)" env-dir)
   (let ((stderr-file (make-temp-file "envrc"))
         result)
     (unwind-protect
         (let ((default-directory env-dir))
           (with-temp-buffer
-            (let ((exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (list t stderr-file) nil "export" "json")))
+            (let ((exit-code (condition-case nil
+                                 (envrc--call-process-with-global-env envrc-direnv-executable nil (list t stderr-file) nil "export" "json")
+                               (quit
+                                (message "interrupted!!")
+                                'interrupted))))
               (envrc--debug "Direnv exited with %s and stderr=%S, stdout=%S"
                             exit-code
                             (with-temp-buffer
                               (insert-file-contents stderr-file)
                               (buffer-string))
                             (buffer-string))
-              (if (zerop exit-code)
+              (if (eq 0 exit-code)
                   (progn
                     (message "Direnv succeeded in %s" env-dir)
                     (if (zerop (buffer-size))
@@ -257,9 +261,9 @@ variable names and values."
                   (insert-file-contents (let (ansi-color-context)
                                           (ansi-color-apply stderr-file)))
                   (goto-char (point-max))
-                  (add-face-text-property initial-pos (point) (if (zerop exit-code) 'success 'error)))
+                  (add-face-text-property initial-pos (point) (if (eq 0 exit-code) 'success 'error)))
                 (insert "\n\n")
-                (unless (zerop exit-code)
+                (when (and (numberp exit-code) (/= 0 exit-code))
                   (display-buffer (current-buffer)))))))
       (delete-file stderr-file))
     result))

--- a/envrc.el
+++ b/envrc.el
@@ -357,7 +357,7 @@ ARGS is as for `call-process'."
   (interactive)
   (envrc--with-required-current-env env-dir
     (let* ((default-directory env-dir)
-           (exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (get-buffer-create "*envrc-allow*") nil "reload")))
+           (exit-code (envrc--call-process-with-global-env envrc-direnv-executable nil (get-buffer-create "*envrc-reload*") nil "reload")))
       (if (zerop exit-code)
           (envrc--update-env env-dir)
         (display-buffer "*envrc-reload*")

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
-;; Package-Version: 0.6
+;; Package-Version: 0.7
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
-;; Package-Version: 0.9
+;; Package-Version: 0.10
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -143,7 +143,7 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode
   (lambda () (when (and (not (minibufferp)) (not (file-remote-p default-directory))
-                        (executable-find "direnv"))
+                        (executable-find envrc-direnv-executable))
                (envrc-mode 1))))
 
 (defface envrc-mode-line-on-face '((t :inherit success))

--- a/envrc.el
+++ b/envrc.el
@@ -322,8 +322,8 @@ also appear in PAIRS."
           (if (fboundp 'eshell-set-path)
               (eshell-set-path path)
             (setq-local eshell-path-env path))))
-      (when-let ((info-path (getenv "INFOPATH")))
-        (setq-local Info-directory-list (parse-colon-path info-path))))))
+      ;; tell info.el to parse INFOPATH again in case direnv modified it
+      (when (getenv "INFOPATH") (setq-local Info-directory-list nil)))))
 
 (defun envrc--update-env (env-dir)
   "Refresh the state of the direnv in ENV-DIR and apply in all relevant buffers."

--- a/envrc.el
+++ b/envrc.el
@@ -63,7 +63,6 @@
 (require 'ansi-color)
 (require 'cl-lib)
 (require 'inheritenv)
-(require 'dash)
 
 ;;; Custom vars and minor modes
 

--- a/envrc.el
+++ b/envrc.el
@@ -142,7 +142,8 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
 
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode
-  (lambda () (unless (or (minibufferp) (file-remote-p default-directory))
+  (lambda () (when (and (not (minibufferp)) (not (file-remote-p default-directory))
+                        (executable-find "direnv"))
                (envrc-mode 1))))
 
 (defface envrc-mode-line-on-face '((t :inherit success))

--- a/envrc.el
+++ b/envrc.el
@@ -5,7 +5,7 @@
 ;; Author: Steve Purcell <steve@sanityinc.com>
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
-;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
+;; Package-Requires: ((emacs "26.1") (inheritenv "0.1"))
 ;; Package-Version: 0.10
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((seq "2") (emacs "25.1") (inheritenv "0.1"))
-;; Package-Version: 0.7
+;; Package-Version: 0.8
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -62,6 +62,7 @@
 (require 'subr-x)
 (require 'ansi-color)
 (require 'cl-lib)
+(require 'diff-mode) ; for its faces
 (require 'inheritenv)
 
 ;;; Custom vars and minor modes

--- a/envrc.el
+++ b/envrc.el
@@ -118,7 +118,7 @@ See `envrc-mode-map' for how to assign a prefix binding to these."
 (defcustom envrc-mode-map (make-sparse-keymap)
   "Keymap for `envrc-mode'.
 To access `envrc-command-map' from this map, give it a prefix keybinding,
-e.g. (define-key envrc-mode-map (kbd \"C-c e\") 'envrc-command-map)"
+e.g. (define-key envrc-mode-map (kbd \"C-c e\") \\='envrc-command-map)"
   :type 'keymap)
 
 ;;;###autoload
@@ -159,7 +159,7 @@ The values are as produced by `envrc--export'.")
 
 (defvar-local envrc--status 'none
   "Symbol indicating state of the current buffer's direnv.
-One of '(none on error).")
+One of \\='(none on error).")
 
 ;;; Internals
 
@@ -234,7 +234,7 @@ MSG and ARGS are as for that function."
 
 (defun envrc--export (env-dir)
   "Export the env vars for ENV-DIR using direnv.
-Return value is either 'error, 'none, or an alist of environment
+Return value is either \\='error, \\='none, or an alist of environment
 variable names and values."
   (unless (envrc--env-dir-p env-dir)
     (error "%s is not a directory with a .envrc" env-dir))

--- a/envrc.el
+++ b/envrc.el
@@ -75,6 +75,10 @@
 Messages are written into the *envrc-debug* buffer."
   :type 'boolean)
 
+(defcustom envrc-update-on-eshell-directory-change t
+  "Whether envrc will update environment when changing directory in eshell."
+  :type 'boolean)
+
 (defcustom envrc-direnv-executable "direnv"
   "The direnv executable used by envrc."
   :type 'string)
@@ -123,8 +127,12 @@ e.g. (define-key envrc-mode-map (kbd \"C-c e\") 'envrc-command-map)"
   :lighter envrc-lighter
   :keymap envrc-mode-map
   (if envrc-mode
-      (envrc--update)
-    (envrc--clear (current-buffer))))
+      (progn
+        (envrc--update)
+        (when (and (equal major-mode 'eshell-mode) envrc-update-on-eshell-directory-change)
+          (add-hook 'eshell-directory-change-hook #'envrc--update nil t)))
+    (envrc--clear (current-buffer))
+    (remove-hook 'eshell-directory-change-hook #'envrc--update t)))
 
 ;;;###autoload
 (define-globalized-minor-mode envrc-global-mode envrc-mode

--- a/envrc.el
+++ b/envrc.el
@@ -424,6 +424,7 @@ in a temp buffer.  ARGS is as for ORIG."
   sh-mode "envrc"
   "Major mode for .envrc files as used by direnv.
 \\{envrc-file-mode-map}"
+  (sh-set-shell "bash")
   (font-lock-add-keywords
    nil `((,(regexp-opt envrc-file-extra-keywords 'symbols)
           (0 font-lock-keyword-face)))))

--- a/envrc.el
+++ b/envrc.el
@@ -286,7 +286,7 @@ variable names and values."
                               (insert-file-contents stderr-file)
                               (buffer-string))
                             (buffer-string))
-              (if (zerop exit-code)
+              (if (eq 0 exit-code) ;; zerop is not an option, as exit-code may sometimes be a symbol
                   (progn
                     (if (zerop (buffer-size))
                         (setq result 'none)

--- a/envrc.el
+++ b/envrc.el
@@ -247,9 +247,9 @@ MSG and ARGS are as for that function."
                              (if val
                                  (if (let ((process-environment (default-value 'process-environment)))
                                        (getenv name))
-                                     '("~" 'diff-changed)
-                                   '("+" 'diff-added))
-                               '("-" 'diff-removed)))
+                                     '("~" diff-changed)
+                                   '("+" diff-added))
+                               '("-" diff-removed)))
                into entries
                finally return (cl-loop for (name prefix face) in (seq-sort-by 'car 'string< entries)
                                        collect (propertize (concat prefix name) 'face face) into strings

--- a/envrc.el
+++ b/envrc.el
@@ -6,7 +6,7 @@
 ;; Keywords: processes, tools
 ;; Homepage: https://github.com/purcell/envrc
 ;; Package-Requires: ((emacs "26.1") (inheritenv "0.1"))
-;; Package-Version: 0.10
+;; Package-Version: 0.11
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/envrc.el
+++ b/envrc.el
@@ -256,7 +256,7 @@ variable names and values."
                 (message "Direnv failed in %s" env-dir)
                 (setq result 'error))
               (envrc--at-end-of-special-buffer "*envrc*"
-                (insert "==== " (format-time-string "%Y-%m-%d %H:%M:%S") " ==== " env-dir " ====\n\n")
+                (insert "──── " (format-time-string "%Y-%m-%d %H:%M:%S") " ──── " env-dir " ────\n\n")
                 (let ((initial-pos (point)))
                   (insert-file-contents (let (ansi-color-context)
                                           (ansi-color-apply stderr-file)))
@@ -439,5 +439,6 @@ in a temp buffer.  ARGS is as for ORIG."
 ;; LocalWords:  envrc direnv
 
 ;; Local Variables:
+;; coding: utf-8
 ;; indent-tabs-mode: nil
 ;; End:

--- a/envrc.el
+++ b/envrc.el
@@ -321,10 +321,9 @@ DIRECTORY is the directory in which the environment changes."
                                       (setq result (let ((json-key-type 'string)) (json-read-from-string stdout)))
                                     (when envrc-show-summary-in-minibuffer
                                       (envrc--show-summary result env-dir)))))
-                            (message "Direnv failed in %s" env-dir)
-                            (setq result 'error)
-                            (setq envrc--running-processes-callbacks (make-hash-table :test 'equal :size 10))
-                            (setq envrc--running-processes (make-hash-table :test 'equal :size 10)))
+                            (progn
+                              (message "Direnv failed in %s" env-dir)
+                              (setq result 'error)))
                           (envrc--at-end-of-special-buffer (envrc--log-buffer-name)
                             (insert "==== " (format-time-string "%Y-%m-%d %H:%M:%S") " ==== " env-dir " ====\n\n")
                             (let ((initial-pos (point)))
@@ -357,7 +356,7 @@ DIRECTORY is the directory in which the environment changes."
        ;; Make sure process is still running.
        (let ((process (gethash cache-key envrc--running-processes)))
          (if (and process (memq (process-status process) '(open run stop)))
-             (puthash cache-key (push callback callbacks) envrc--running-processes-callbacks)
+             (puthash cache-key (cons callback callbacks) envrc--running-processes-callbacks)
            (progn
              (remhash cache-key envrc--running-processes)
              (envrc--export-new-process env-dir callback))))))))

--- a/envrc.el
+++ b/envrc.el
@@ -322,7 +322,9 @@ DIRECTORY is the directory in which the environment changes."
                                     (when envrc-show-summary-in-minibuffer
                                       (envrc--show-summary result env-dir)))))
                             (message "Direnv failed in %s" env-dir)
-                            (setq result 'error))
+                            (setq result 'error)
+                            (setq envrc--running-processes-callbacks (make-hash-table :test 'equal :size 10))
+                            (setq envrc--running-processes (make-hash-table :test 'equal :size 10)))
                           (envrc--at-end-of-special-buffer (envrc--log-buffer-name)
                             (insert "==== " (format-time-string "%Y-%m-%d %H:%M:%S") " ==== " env-dir " ====\n\n")
                             (let ((initial-pos (point)))


### PR DESCRIPTION
stdout is already stored in a variable, so there’s no need to move around the buffer with goto-char.